### PR TITLE
Remove shared memory option

### DIFF
--- a/1.13/Dockerfile
+++ b/1.13/Dockerfile
@@ -11,7 +11,7 @@ RUN apt update \
   && tar xvf /ngt/v${NGT_VERSION}.tar.gz -C /ngt \
   && mkdir /ngt/NGT-${NGT_VERSION}/build \
   && cd /ngt/NGT-${NGT_VERSION}/build \
-  && cmake -DNGT_SHARED_MEMORY_ALLOCATOR=ON .. \
+  && cmake .. \
   && make \
   && make install \
   && ldconfig \

--- a/1.14/Dockerfile
+++ b/1.14/Dockerfile
@@ -11,7 +11,7 @@ RUN apt update \
   && tar xvf /ngt/v${NGT_VERSION}.tar.gz -C /ngt \
   && mkdir /ngt/NGT-${NGT_VERSION}/build \
   && cd /ngt/NGT-${NGT_VERSION}/build \
-  && cmake -DNGT_SHARED_MEMORY_ALLOCATOR=ON .. \
+  && cmake .. \
   && make \
   && make install \
   && ldconfig \


### PR DESCRIPTION
- remove shared memory option for golang api
  - we cannot use gongt when shared memory option is on