### PR TITLE
[ML-2167] apt にオプションを追加

### DIFF
--- a/1.13/Dockerfile
+++ b/1.13/Dockerfile
@@ -2,7 +2,7 @@ FROM gunosy/ci-go:1.13
 
 ENV NGT_VERSION=1.12.1
 
-RUN apt update \
+RUN apt --allow-releaseinfo-change update \
   && apt install -y --no-install-recommends cmake \
   && apt clean \
   && rm -rf /var/lib/apt/lists/* \

--- a/1.14/Dockerfile
+++ b/1.14/Dockerfile
@@ -2,7 +2,7 @@ FROM gunosy/ci-go:1.14
 
 ENV NGT_VERSION=1.12.1
 
-RUN apt update \
+RUN apt --allow-releaseinfo-change update \
   && apt install -y --no-install-recommends cmake \
   && apt clean \
   && rm -rf /var/lib/apt/lists/* \

--- a/1.15/Dockerfile
+++ b/1.15/Dockerfile
@@ -2,7 +2,7 @@ FROM gunosy/ci-go:1.15
 
 ENV NGT_VERSION=1.12.1
 
-RUN apt update \
+RUN apt --allow-releaseinfo-change update \
   && apt install -y --no-install-recommends cmake \
   && apt clean \
   && rm -rf /var/lib/apt/lists/* \

--- a/1.23/Dockerfile
+++ b/1.23/Dockerfile
@@ -2,7 +2,7 @@ FROM gunosy/ci-go:1.23
 
 ENV NGT_VERSION=1.12.1
 
-RUN apt update \
+RUN apt --allow-releaseinfo-change update \
   && apt install -y --no-install-recommends cmake \
   && apt clean \
   && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
## 概要

- carrot-prescott-api の CI が落ちてしまうため、go 1.23 のイメージを作成したが、apt で落ちた
- そこで、apt にオプションを追加して、通るようにした
  - 参考: https://obel.hatenablog.jp/entry/20210822/1629577800 