### PR TITLE
[ML-2167] ci-go の脱却

### DIFF
--- a/1.23/Dockerfile
+++ b/1.23/Dockerfile
@@ -1,4 +1,4 @@
-FROM gunosy/ci-go:1.23
+FROM golang:1.23
 
 ENV NGT_VERSION=1.12.1
 


### PR DESCRIPTION
## 概要

- carrot-prescott-api の CI が落ちてしまうため、go 1.23 のイメージを作成したが、apt で落ちた
- apt にオプションを追加して通るようになったが、ci-go がアーカイブされていて落ちた
- そこで、ci-go を脱却して、golang で直接指定するようにした