### PR TITLE
[ML-2167] golangci-lint の追加

### DIFF
--- a/1.23/Dockerfile
+++ b/1.23/Dockerfile
@@ -1,9 +1,10 @@
 FROM golang:1.23
 
 ENV NGT_VERSION=1.12.1
+ENV GOLANGCI_LINT_VERSION=v1.62.2
 
 RUN apt --allow-releaseinfo-change update \
-  && apt install -y --no-install-recommends cmake \
+  && apt install -y --no-install-recommends cmake make libssl-dev libghc-zlib-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip git \
   && apt clean \
   && rm -rf /var/lib/apt/lists/* \
   && mkdir -p /ngt \
@@ -17,3 +18,5 @@ RUN apt --allow-releaseinfo-change update \
   && ldconfig \
   && cd /go \
   && rm -rf /ngt
+
+RUN GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}


### PR DESCRIPTION
## 概要

- carrot-prescott-api の CI が落ちてしまうため、go 1.23 のイメージを作成したが、apt で落ちた
- apt にオプションを追加して通るようになったが、ci-go がアーカイブされていて落ちた
- ci-go を脱却するために、golang で直接指定するようにした
- ただ、golangci-lint が足りてなくて、エラーが出る
- そこで、golangci-lint を追加した