### PR TITLE
[ML-2167] go install に変更

### DIFF
--- a/1.23/Dockerfile
+++ b/1.23/Dockerfile
@@ -19,4 +19,4 @@ RUN apt --allow-releaseinfo-change update \
   && cd /go \
   && rm -rf /ngt
 
-RUN GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}
+RUN GO111MODULE=on go install github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}


### PR DESCRIPTION
## 概要

- carrot-prescott-api の CI が落ちてしまうため、go 1.23 のイメージを作成したが、apt で落ちた
- apt にオプションを追加して通るようになったが、ci-go がアーカイブされていて落ちた
- ci-go を脱却するために、golang で直接指定するようにした
- golangci-lint が足りてなくて、golangci-lint を追加したが、go get コマンドがダメだった
- そこで、go install に変更した