### PR TITLE
[ML-2397] 変更バージョンのみビルドする

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,9 +39,22 @@ jobs:
       - run:
           name: Build and push docker image
           command: |
-            for tag in $( find . -follow -name Dockerfile | sed "s/^.\/\(.*\)\/Dockerfile/\1/g" ); do
-              docker build -f ${tag}/Dockerfile . -t gunosy/ci-go-ngt:${tag}
-              docker push gunosy/ci-go-ngt:${tag}
+            # merge-baseを使用してベースブランチからの変更を検出し、パスを整形
+            CHANGED_TAGS=$(git diff --name-only $(git merge-base origin/master HEAD) | grep "Dockerfile" | sed "s/\(.*\)\/Dockerfile/\1/g")
+
+            if [ -z "$CHANGED_TAGS" ]; then
+              echo "No Dockerfile changes detected. Skipping build."
+              exit 0
+            fi
+            
+            echo "Building tags: ${CHANGED_TAGS}"
+            
+            for tag in $CHANGED_TAGS; do
+              if [ -f "${tag}/Dockerfile" ]; then
+                echo "Building ${tag}..."
+                docker build -f ${tag}/Dockerfile . -t gunosy/ci-go-ngt:${tag}
+                docker push gunosy/ci-go-ngt:${tag}
+              fi
             done
 
 workflows:

--- a/1.13/Dockerfile
+++ b/1.13/Dockerfile
@@ -5,7 +5,6 @@ ENV NGT_VERSION=1.12.1
 RUN apt --allow-releaseinfo-change update \
   && apt install -y --no-install-recommends cmake \
   && apt clean \
-  && rm -rf /var/lib/apt/lists/* \
   && mkdir -p /ngt \
   && wget -P /ngt https://github.com/yahoojapan/NGT/archive/v${NGT_VERSION}.tar.gz \
   && tar xvf /ngt/v${NGT_VERSION}.tar.gz -C /ngt \


### PR DESCRIPTION
- 背景
  - 特定のdocker イメージしか変更していなくても、全部のバージョンをビルドし直す状態だった
- 作業内容
  - 変更したdocker イメージのみビルドを走らせるように修正した
- JIRA
  - https://gunosy.atlassian.net/browse/ML-2397 